### PR TITLE
+proper $variable detection (no digits first)

### DIFF
--- a/XYplorer.tmLanguage
+++ b/XYplorer.tmLanguage
@@ -91,7 +91,7 @@
 			<key>name</key>
 			<string>variable.parameter.xys</string>
 			<key>match</key>
-			<string>\|:\w+|(?i)\$\w+|\{:(Text|Image|Photo|Audio|Video|Media|Font|Vector|Web|Office|Archive|Executable)\}</string>
+			<string>\|:\w+|(?i)\$[a-z_]\w*|\{:(Text|Image|Photo|Audio|Video|Media|Font|Vector|Web|Office|Archive|Executable)\}</string>
 		</dict>
 
 		<dict>


### PR DESCRIPTION
variable names beginning with a number `$1var` is invalid, so not hilited.